### PR TITLE
Fix filename search by not calling __str__() on tuple.

### DIFF
--- a/service.py
+++ b/service.py
@@ -350,7 +350,7 @@ def search_manual(searchstr, languages, filename):
 
 
 def search_filename(filename, languages):
-    title, year = str(xbmc.getCleanMovieTitle(filename))
+    title, year = xbmc.getCleanMovieTitle(filename)
     log(__name__, "clean title: \"%s\" (%s)" % (title, year))
     try:
         yearval = int(year)


### PR DESCRIPTION
the __str__() method was called on the tuple returned from
xbmc.getCleanMovieTitle(). This causes the unpacking to
title and year to fail as it tried to unpack the string instead
of the tuple.

Fixes  #4